### PR TITLE
Verify commitment count against VK

### DIFF
--- a/gnark-solana/crates/verifier-bin/src/lib.rs
+++ b/gnark-solana/crates/verifier-bin/src/lib.rs
@@ -29,7 +29,8 @@ pub fn process_instruction(
     let proof_len = instruction_data.len() - (12 + NR_INPUTS * 32);
     let proof_bytes = &instruction_data[..proof_len];
 
-    let proof = GnarkProof::from_bytes(proof_bytes).map_err(|e| {
+    const N_COMMITMENTS: usize = generated_vk::VK.commitment_keys.len();
+    let proof = GnarkProof::<N_COMMITMENTS>::from_bytes(proof_bytes).map_err(|e| {
         msg!("Gnark error: {:?}", e);
         ProgramError::Custom(u32::from(e))
     })?;

--- a/gnark-solana/crates/verifier-lib/src/verifier.rs
+++ b/gnark-solana/crates/verifier-lib/src/verifier.rs
@@ -63,9 +63,9 @@ impl<const NR_INPUTS: usize> GnarkVerifier<'_, NR_INPUTS> {
     ///
     /// The proof is accepted if and only if the above product of pairings equals
     /// the identity element in the target group.
-    pub fn verify(
+    pub fn verify<const N_COMMITMENTS: usize>(
         &mut self,
-        proof: GnarkProof,
+        proof: GnarkProof<N_COMMITMENTS>,
         public_witness: GnarkWitness<NR_INPUTS>,
     ) -> Result<(), GnarkError> {
         let mut public_witness_vec = public_witness.entries.to_vec();

--- a/gnark-solana/crates/verifier-lib/src/verifier_test.rs
+++ b/gnark-solana/crates/verifier-lib/src/verifier_test.rs
@@ -21,7 +21,7 @@ mod tests {
 
         let proof_file =
             File::open("src/test_files/sum_a_b.proof").expect("unable to open proof file");
-        let proof = GnarkProof::parse(proof_file).expect("Unable to parse proof");
+        let proof = GnarkProof::<0>::parse(proof_file).expect("Unable to parse proof");
 
         let pw_file = File::open("src/test_files/sum_a_b.pw").expect("unable to open pw file");
 
@@ -42,7 +42,7 @@ mod tests {
 
         let proof_file =
             File::open("src/test_files/keccak_f1600.proof").expect("unable to open proof file");
-        let proof = GnarkProof::parse(proof_file).expect("Unable to parse proof");
+        let proof = GnarkProof::<1>::parse(proof_file).expect("Unable to parse proof");
 
         let pw_file = File::open("src/test_files/keccak_f1600.pw").expect("unable to open pw file");
 
@@ -63,7 +63,7 @@ mod tests {
         let mut verifier = GnarkVerifier::<'_, NR_INPUTS>::new(&vk);
 
         let proof_file = File::open("src/test_files/xor.proof").expect("unable to open proof file");
-        let proof = GnarkProof::parse(proof_file).expect("Unable to parse proof");
+        let proof = GnarkProof::<1>::parse(proof_file).expect("Unable to parse proof");
 
         let pw_file = File::open("src/test_files/xor.pw").expect("unable to open pw file");
 

--- a/gnark-solana/crates/verifier-lib/src/vk.rs
+++ b/gnark-solana/crates/verifier-lib/src/vk.rs
@@ -142,7 +142,7 @@ fn read_u64(reader: &mut impl Read) -> io::Result<u64> {
     Ok(u64::from_be_bytes(buf))
 }
 
-fn read_u32(reader: &mut impl Read) -> io::Result<u32> {
+pub(crate) fn read_u32(reader: &mut impl Read) -> io::Result<u32> {
     let mut buf = [0u8; 4];
     reader.read_exact(&mut buf)?;
     Ok(u32::from_be_bytes(buf))

--- a/gnark-solana/example/program/src/lib.rs
+++ b/gnark-solana/example/program/src/lib.rs
@@ -44,7 +44,8 @@ pub fn process_instruction(
     let proof_len = instruction_data.len() - (12 + NR_INPUTS * 32);
     let proof_bytes = &instruction_data[..proof_len];
 
-    let proof = GnarkProof::from_bytes(proof_bytes).map_err(|e| {
+    const N_COMMITMENTS: usize = vk::VK.commitment_keys.len();
+    let proof = GnarkProof::<N_COMMITMENTS>::from_bytes(proof_bytes).map_err(|e| {
         msg!("Gnark error: {:?}", e);
         ProgramError::Custom(u32::from(e))
     })?;


### PR DESCRIPTION
**Description**
- Validate proof commitment count against VK and allocate using the VK’s expected count
- Use the bounded parser in verifier-bin and the example program
- Add unit test for the bounded parser

closes: https://github.com/reilabs/sunspot/issues/43